### PR TITLE
Fold on current line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Keybindings:
 
 ## Markers
 Markers tell this package, where it should fold. The following markers are available:
-  * `@atom-fold here`: Marks the next line for folding
+  * `@atom-fold here`: Marks the current line for folding
+  * `@atom-fold next`: Marks the next line for folding
   * `@atom-fold regex /regex1/ /regex2/ ...`: marks all lines, which match the specified regexes
     * must be on the first commented line in the file!

--- a/lib/auto-fold.coffee
+++ b/lib/auto-fold.coffee
@@ -5,6 +5,16 @@ module.exports = AutoFold =
       description: "Automatically auto-fold new files, when they are opened"
       type: 'boolean'
       default: true
+    defaultInlineMarker:
+      title: "Default inline Marker"
+      description: "Marker triggering auto-fold on current line. Needs to be last text in line."
+      type: 'string'
+      default: '@auto-fold here'
+    defaultNextLineMarker:
+      title: "Default next line Marker"
+      description: "Marker triggering auto-fold on the next line. Should appear in commented part of line."
+      type: 'string'
+      default: '@auto-fold next'
 
   activate: (state) ->
     atom.commands.add 'atom-workspace', 'auto-fold:toggle': => @toggle()
@@ -22,8 +32,12 @@ module.exports = AutoFold =
 
   doFold: (action, editor) ->
     editor ?= atom.workspace.getActiveTextEditor()
+    defaultInlineMarker   = atom.config.get('auto-fold.defaultInlineMarker')
+    defaultNextLineMarker = atom.config.get('auto-fold.defaultNextLineMarker')
 
     regexes = []
+    if defaultInlineMarker
+      regexes.push new RegExp(defaultInlineMarker + '\s*$')
     for row in [0..editor.getLastBufferRow()]
       continue unless editor.isBufferRowCommented(row)
       if editor.lineTextForBufferRow(row).indexOf("@auto-fold regex") != -1
@@ -38,7 +52,7 @@ module.exports = AutoFold =
       for row in [0..editor.getLastBufferRow()]
         if editor.isFoldableAtBufferRow(row) && (foldNext || regexes.some((r) -> editor.lineTextForBufferRow(row).match(r)?))
           any = true if f(row)
-        foldNext = editor.isBufferRowCommented(row) && editor.lineTextForBufferRow(row).indexOf("@auto-fold here") != -1
+        foldNext = editor.isBufferRowCommented(row) && editor.lineTextForBufferRow(row).indexOf(defaultNextLineMarker) != -1
       return any
 
     if action == 'toggle'

--- a/test.coffee
+++ b/test.coffee
@@ -6,8 +6,12 @@ else
   if 2 == 4 then
     console.log "b"
   console.log
-    a: 1
-    # @auto-fold here
+    a:
+      1
+    # @auto-fold next
     b:
       c: "x"
       d: "y"
+    d: # @auto-fold here
+      e: "z"
+      f: "q"


### PR DESCRIPTION
This is a change that allows to fold on _current_ line.
Additionally settings page gains ability to set default markers for both _fold on next line_ and _fold on current line_.

I find your package essential for my notes text files. This change allows me to keep everything lean & clean - without loosing space for additional lines with fold markers.
My default marker (for current line) is " ><$" (where $ is EOL). In text file looks like this:

```
My great new project  ><
    Description
        Next big idea to conquer the world
    ToDo
        Write the idea down

Another fine idea   ><
   Haven't came to me yet ;-)
```

Folded:

```
My great new project  ><
Another fine idea   ><
```

Had to change existing _@atom-fold here_ marker to _@atom-fold next_ to keep the naming consistent.
I hope this isn't a big problem. ...In case it is, settings page allows to overwrite the defaults. :wink: 

The only thing that is lacking in this commit is an updated demo graphic.
